### PR TITLE
Warning fix [-Wreorder]. Fix initial blink in DigitalOutput.

### DIFF
--- a/OnixartsIO.cpp
+++ b/OnixartsIO.cpp
@@ -5,10 +5,10 @@ using namespace Onixarts::Tools::IO;
 DigitalOutput::DigitalOutput(byte outputPin, bool outputActiveLevelHigh)
 	: m_outputPin(outputPin)
 	, m_outputActiveLevel(outputActiveLevelHigh ? HIGH : LOW)
-	, blinkingTask(this)
-	, delayTask(this)
 	, m_isBlinkingModeEnabled(false)
 	, m_scheduledEvent(Event::None)
+	, blinkingTask(this)
+	, delayTask(this)
 {
 }
 void DigitalOutput::Init()
@@ -165,8 +165,8 @@ bool SimpleDigitalInput::IsPressed()
 //---------------------------------------------------------------------------------------
 
 DigitalInput::DigitalInput(byte inputPin, bool enablePullUpResistor, byte inputActiveLevel)
-	: debouncingTask(this)
-	, SimpleDigitalInput(inputPin, enablePullUpResistor, inputActiveLevel )
+	: SimpleDigitalInput(inputPin, enablePullUpResistor, inputActiveLevel )
+	,debouncingTask(this)
 {
 }
 

--- a/OnixartsIO.cpp
+++ b/OnixartsIO.cpp
@@ -13,6 +13,7 @@ DigitalOutput::DigitalOutput(byte outputPin, bool outputActiveLevelHigh)
 }
 void DigitalOutput::Init()
 {
+	digitalWrite(m_outputPin, !m_outputActiveLevel);
 	pinMode(m_outputPin, OUTPUT);
 
 	AddTask(blinkingTask);


### PR DESCRIPTION
Kosmetyczna zmiana kolejności inicjalizacji parametrów, żeby uniknąć ostrzeżenia.